### PR TITLE
Add https to avoid mixed content issue

### DIFF
--- a/mtg-pairings-server/resources/public/index.html
+++ b/mtg-pairings-server/resources/public/index.html
@@ -15,7 +15,7 @@
   <script src="js/controllers.js"></script>
   <script src="js/resources.js"></script>
   <script src="js/app.js"></script>
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" type="text/css" href="css/main.css">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/bootstrap-theme.css">


### PR DESCRIPTION
Fixes mixed content when we tried to load google styles from non-SSL endpoint ``` http://fonts.googleapis.com/css?family=Lato:400,700 ```. 